### PR TITLE
[IOS2-1050-1] generateAccessibilityDescription의 구현을, 각 요소별로 리팩토링합니다.

### DIFF
--- a/Sources/AXSnapshot/AccessibilityDescription.swift
+++ b/Sources/AXSnapshot/AccessibilityDescription.swift
@@ -27,7 +27,7 @@ public var generateAccessibilityDescription: (NSObject) -> String = { object in
     return description
 }
 
-var generateAccessbilityLabelDescription: (NSObject) -> String = { object in
+public var generateAccessbilityLabelDescription: (NSObject) -> String = { object in
     var description = ""
     if let label = object.accessibilityLabel, label.count > 0 {
         description = label
@@ -36,7 +36,7 @@ var generateAccessbilityLabelDescription: (NSObject) -> String = { object in
     return description
 }
 
-var generateAccessibilityValueDescription: (NSObject) -> String = { object in
+public var generateAccessibilityValueDescription: (NSObject) -> String = { object in
     var description = ""
     if let value = object.accessibilityValue, value.count > 0 {
         description = value
@@ -44,7 +44,7 @@ var generateAccessibilityValueDescription: (NSObject) -> String = { object in
     return description
 }
 
-var generateAccessibilityTraitDescription: (NSObject) -> String = { object in
+public var generateAccessibilityTraitDescription: (NSObject) -> String = { object in
     var description = ""
     if object.accessibilityTraits.isEmpty == false {
         description = "\n\(object.accessibilityTraits.descripion)"
@@ -52,7 +52,7 @@ var generateAccessibilityTraitDescription: (NSObject) -> String = { object in
     return description
 }
 
-var generateAccessibilityHintDescription: (NSObject) -> String = { object in
+public var generateAccessibilityHintDescription: (NSObject) -> String = { object in
     var description = ""
     if let hint = object.accessibilityHint {
         description = "\n\(hint)"
@@ -60,7 +60,7 @@ var generateAccessibilityHintDescription: (NSObject) -> String = { object in
     return description
 }
 
-var generateAccessibilityCustomActionsDescription: (NSObject) -> String = { object in
+public var generateAccessibilityCustomActionsDescription: (NSObject) -> String = { object in
     var description = ""
     if let actions = object.accessibilityCustomActions {
         description += "\n"

--- a/Sources/AXSnapshot/AccessibilityDescription.swift
+++ b/Sources/AXSnapshot/AccessibilityDescription.swift
@@ -17,8 +17,8 @@ public var generateAccessibilityDescription: (NSObject) -> String = { object in
     let accessibilityValueDescription = generateAccessibilityValueDescription(object)
     if accessibilityValueDescription.count > 0, description.count > 0 {
         description += ", "
-        description += accessibilityValueDescription
     }
+    description += accessibilityValueDescription
 
     description += generateAccessibilityTraitDescription(object)
     description += generateAccessibilityHintDescription(object)

--- a/Sources/AXSnapshot/AccessibilityDescription.swift
+++ b/Sources/AXSnapshot/AccessibilityDescription.swift
@@ -1,6 +1,6 @@
 //
 //  AccessibilityDescription.swift
-//  
+//
 //
 //  Created by Sungdoo on 2022/03/12.
 //
@@ -12,35 +12,61 @@ import UIKit
 ///
 /// Replace this closure to generate your custom snapshot format
 public var generateAccessibilityDescription: (NSObject) -> String = { object in
+    var description = generateAccessbilityLabelDescription(object)
+
+    let accessibilityValueDescription = generateAccessibilityValueDescription(object)
+    if accessibilityValueDescription.count > 0, description.count > 0 {
+        description += ", "
+        description += accessibilityValueDescription
+    }
+
+    description += generateAccessibilityTraitDescription(object)
+    description += generateAccessibilityHintDescription(object)
+    description += generateAccessibilityCustomActionsDescription(object)
+
+    return description
+}
+
+var generateAccessbilityLabelDescription: (NSObject) -> String = { object in
     var description = ""
-    
     if let label = object.accessibilityLabel, label.count > 0 {
-        description += label
+        description = label
     }
-    
+
+    return description
+}
+
+var generateAccessibilityValueDescription: (NSObject) -> String = { object in
+    var description = ""
     if let value = object.accessibilityValue, value.count > 0 {
-        if description.count > 0 {
-            description += ", "
-        }
-        description += value
+        description = value
     }
+    return description
+}
 
+var generateAccessibilityTraitDescription: (NSObject) -> String = { object in
+    var description = ""
     if object.accessibilityTraits.isEmpty == false {
-        description += "\n"
-        description += object.accessibilityTraits.descripion
+        description = "\n\(object.accessibilityTraits.descripion)"
     }
+    return description
+}
 
+var generateAccessibilityHintDescription: (NSObject) -> String = { object in
+    var description = ""
     if let hint = object.accessibilityHint {
-        description += "\n"
-        description += hint
+        description = "\n\(hint)"
     }
+    return description
+}
 
+var generateAccessibilityCustomActionsDescription: (NSObject) -> String = { object in
+    var description = ""
     if let actions = object.accessibilityCustomActions {
         description += "\n"
         description += "Actions: "
         description += actions.map { $0.name }.joined(separator: ", ")
     }
-
     return description
 }
 


### PR DESCRIPTION
Related Ticket:  IOS2-1051

현재 AXSnapshot은 BPL 컴퍼넌트에 대해서는 기대대로 행동하지만, 
기본 UIKit Control을 활용한 커스텀 뷰에 대해서는 그렇지 않습니다. 
왜냐하면 기본 UIKit Control들은 isAccessibilityElement값이 false여도 기본적으로 AssistiveTechnology에 노출되는데, 현재 AXSnapshot에서는 이 부분을 무시하고 있기 때문입니다. 그래서 실제로 VoiceOver에는 노출되는 요소들이 AXSnapshot에는 노출되지 않는 이슈가 있습니다.  

---

이 이슈를 하기 위한 첫 번째 스텝으로, `generateAccessibilityDescription` 의 구현체를, 각 요소 (label, value, trait, hint 등)별로 리팩토링합니다. 다음 PR들에서는 각 요소별 로직을 각각 개선합니다.