### PR TITLE
[IOS2-1050-2] Standard UIKit Control에 대하여, 별도의 accessibilityDescription 생성 로직을 적용합니다.

### DIFF
--- a/Sources/AXSnapshot/AccessibilityDescription.swift
+++ b/Sources/AXSnapshot/AccessibilityDescription.swift
@@ -29,17 +29,52 @@ public var generateAccessibilityDescription: (NSObject) -> String = { object in
 
 public var generateAccessbilityLabelDescription: (NSObject) -> String = { object in
     var description = ""
+
     if let label = object.accessibilityLabel, label.count > 0 {
         description = label
+    } else if let labelText = (object as? UILabel)?.text, labelText.count > 0 {
+        description = labelText
+    } else if let buttonText = (object as? UIButton)?.titleLabel?.text, buttonText.count > 0 {
+        description = buttonText
+    } else if let activityIndicator = object as? UIActivityIndicatorView {
+        description = "Activity Indicator"
+    } else if let stepper = object as? UIStepper {
+        description = "Stepper"
+    } else if let segmentedControl = object as? UISegmentedControl {
+        description = "SegmentedControl with \(segmentedControl.numberOfSegments) segments"
     }
-
     return description
 }
 
 public var generateAccessibilityValueDescription: (NSObject) -> String = { object in
     var description = ""
+
     if let value = object.accessibilityValue, value.count > 0 {
         description = value
+    } else if let progressView = object as? UIProgressView {
+        let numberFormatter = NumberFormatter()
+        numberFormatter.numberStyle = .percent
+        let progress = numberFormatter.string(for: progressView.progress) ?? ""
+        description = progress
+    } else if let slider = object as? UISlider {
+        let numberFormatter = NumberFormatter()
+        numberFormatter.numberStyle = .percent
+        let percentage = numberFormatter.string(for: slider.value / (slider.maximumValue - slider.minimumValue)) ?? ""
+        description = "Absolute: \(slider.value), Percentage: \(percentage)"
+    } else if let textField = object as? UITextField {
+        description = textField.text ?? ""
+    } else if let textView = object as? UITextView {
+        description = textView.text ?? ""
+    } else if let activityIndicator = object as? UIActivityIndicatorView {
+        description = activityIndicator.isAnimating ? "Animating" : "Halted"
+    } else if let uiSwitch = object as? UISwitch {
+        description = uiSwitch.isOn ? "1" : "0"
+    } else if let segmentedControl = object as? UISegmentedControl {
+        if segmentedControl.selectedSegmentIndex >= 0 {
+            description = "Selected: \(segmentedControl.titleForSegment(at: segmentedControl.selectedSegmentIndex) ?? "")"
+        } else {
+            description = "Selected: None"
+        }
     }
     return description
 }
@@ -48,6 +83,10 @@ public var generateAccessibilityTraitDescription: (NSObject) -> String = { objec
     var description = ""
     if object.accessibilityTraits.isEmpty == false {
         description = "\n\(object.accessibilityTraits.descripion)"
+    } else if object is UIButton || object is UISwitch {
+        description = "\n\(UIAccessibilityTraits.button.descripion)"
+    } else if object is UISlider {
+        description = "\n\(UIAccessibilityTraits.adjustable.descripion)"
     }
     return description
 }


### PR DESCRIPTION
Related Ticket: [IOS2-1052](http://banksalad.atlassian.net/browse/IOS2-1052)

대부분의 Standard UIkit Controls는,  `accessibilityLabel, accessibilityValue` 등이 nil 이어도 VoiceOver에게 적절한 값이 노출됩니다. 

이 행동을 반영하여 generateAccessibilityDescription 로직들을 업데이트합니다. 

## 테스트한 UIKit Control의 목록 

- [x] UILabel
- [x] UIButton
- [x] UISwitch
- [x] UISegmentedControl
- [x] UIStepper
- [x] UISlider
- [x] UITextField
- [x] UITextView
- [x] UIActivityIndicator


다음 PR에서 자동화된 테스트를 추가할 예정입니다.