### PR TITLE
[IOS2-1050-3] Standard UIKitControl은 `isExposedToAssistiveTechnology` 가 반드시 true가 되도록 합니다

### DIFF
--- a/Sources/AXSnapshot/UIResponder+Extension.swift
+++ b/Sources/AXSnapshot/UIResponder+Extension.swift
@@ -1,6 +1,6 @@
 //
 //  UIResponder+Extension.swift
-//  
+//
 //
 //  Created by Sungdoo on 2022/03/12.
 //
@@ -10,7 +10,7 @@ import UIKit
 
 extension UIResponder {
     var isExposedToAssistiveTech: Bool {
-        if isAccessibilityElement {
+        if shouldForceExposeToAssistiveTech || isAccessibilityElement {
             if allItemsInResponderChain.contains(where: { $0.isExposedToAssistiveTech }) == true {
                 return false
             } else {
@@ -19,6 +19,32 @@ extension UIResponder {
         } else {
             return false
         }
+    }
+
+    /// A boolean value indicates that the elment is exposed to AssistiveTechnology even if `isAccessibilityElement` is false
+    ///
+    /// Standard UIKit Controlst are not exposed to AssistiveTechnology when its `hidden` value is true
+    /// - Date: 2022. 04. 02
+    var shouldForceExposeToAssistiveTech: Bool {
+        guard let view = self as? UIView else { return false }
+        return view.isStandardUIKitControl && view.isHidden == false
+    }
+
+    /// A boolean value indicates that the elment is standard UIKit Control
+    ///
+    /// Standard UIKit Controlst are exposed to AssistiveTechnology even if  value of`isAccessibilityElement` is false
+    /// - Date: 2022. 04. 02
+    var isStandardUIKitControl: Bool {
+        (self is UIProgressView) ||
+            (self is UILabel) ||
+            (self is UIButton) ||
+            (self is UISlider) ||
+            (self is UISwitch) ||
+            (self is UITextView) ||
+            (self is UIActivityIndicatorView) ||
+            (self is UIStepper) ||
+            (self is UISegmentedControl) ||
+            (self is UITextField)
     }
 
     var allItemsInResponderChain: [UIResponder] {


### PR DESCRIPTION
Related Ticket: [IOS2-1053](http://banksalad.atlassian.net/browse/IOS2-1053)

대부분의 Standard UIkit Controls는, `isAccessibilityElement = false` 여도 VoiceOver에게 적절한 값이 노출됩니다. 

이 행동을 반영하여 generateAccessibilityDescription 로직들을 업데이트합니다. 

## 테스트한 UIKit Control의 목록 

- [x] UILabel
- [x] UIButton
- [x] UISwitch
- [x] UISegmentedControl
- [x] UIStepper
- [x] UISlider
- [x] UITextField
- [x] UITextView
- [x] UIActivityIndicator


다음 PR에서 자동화된 테스트를 추가할 예정입니다.
