### PR TITLE
[IOS2-1050-4] UITextView/TextField의 accessibilityTrait 반영

### DIFF
--- a/Sources/AXSnapshot/AccessibilityDescription.swift
+++ b/Sources/AXSnapshot/AccessibilityDescription.swift
@@ -81,12 +81,16 @@ public var generateAccessibilityValueDescription: (NSObject) -> String = { objec
 
 public var generateAccessibilityTraitDescription: (NSObject) -> String = { object in
     var description = ""
-    if object.accessibilityTraits.isEmpty == false {
+    if object.accessibilityTraits.isEmpty == false && object.accessibilityTraits.isStandardTraits {
         description = "\n\(object.accessibilityTraits.descripion)"
     } else if object is UIButton || object is UISwitch {
         description = "\n\(UIAccessibilityTraits.button.descripion)"
     } else if object is UISlider {
         description = "\n\(UIAccessibilityTraits.adjustable.descripion)"
+    } else if object is UITextView {
+        description = "\nTextView"
+    } else if object is UITextField {
+        description = "\nTextField"
     }
     return description
 }

--- a/Sources/AXSnapshot/UIAccessibilityTraits+Extension.swift
+++ b/Sources/AXSnapshot/UIAccessibilityTraits+Extension.swift
@@ -1,6 +1,6 @@
 //
-//  File.swift
-//  
+//  UIAccessibilityTraits+Extension.swift
+//
 //
 //  Created by Sungdoo on 2022/03/12.
 //
@@ -12,31 +12,31 @@ extension UIAccessibilityTraits {
     var descripion: String {
         var traits: [String] = []
 
-        if self.contains(.button) {
+        if contains(.button) {
             traits.append("button")
         }
 
-        if self.contains(.link) {
+        if contains(.link) {
             traits.append("link")
         }
 
-        if self.contains(.image) {
+        if contains(.image) {
             traits.append("image")
         }
 
-        if self.contains(.searchField) {
+        if contains(.searchField) {
             traits.append("searchField")
         }
 
-        if self.contains(.keyboardKey) {
+        if contains(.keyboardKey) {
             traits.append("keyboardKey")
         }
 
-        if self.contains(.staticText) {
+        if contains(.staticText) {
             traits.append("staticText")
         }
 
-        if self.contains(.header) {
+        if contains(.header) {
             traits.append("header")
         }
 
@@ -46,40 +46,50 @@ extension UIAccessibilityTraits {
             }
         }
 
-        if self.contains(.summaryElement) {
+        if contains(.summaryElement) {
             traits.append("summaryElement")
         }
 
-        if self.contains(.selected) {
+        if contains(.selected) {
             traits.append("selected")
         }
 
-        if self.contains(.notEnabled) {
+        if contains(.notEnabled) {
             traits.append("notEnabled")
         }
 
-        if self.contains(.adjustable) {
+        if contains(.adjustable) {
             traits.append("adjustable")
         }
 
-        if self.contains(.allowsDirectInteraction) {
+        if contains(.allowsDirectInteraction) {
             traits.append("allowsDirectInteraction")
         }
 
-        if self.contains(.updatesFrequently) {
+        if contains(.updatesFrequently) {
             traits.append("updatesFrequently")
         }
 
-        if self.contains(.causesPageTurn) {
+        if contains(.causesPageTurn) {
             traits.append("causesPageTurn")
         }
 
-        if self.contains(.playsSound) {
+        if contains(.playsSound) {
             traits.append("playsSound")
         }
 
-        if self.contains(.startsMediaSession) {
+        if contains(.startsMediaSession) {
             traits.append("startsMediaSession")
+        }
+
+        // accessibilityTraits of UITextView and UITextFields are not declared as constant.
+        // - Date: 2022.04.02
+        if rawValue == 262_144 {
+            traits.append("text field")
+        }
+
+        if rawValue == 140_737_488_617_472 {
+            traits.append("text view")
         }
 
         return traits.joined(separator: ", ")

--- a/Sources/AXSnapshot/UIAccessibilityTraits+Extension.swift
+++ b/Sources/AXSnapshot/UIAccessibilityTraits+Extension.swift
@@ -10,6 +10,8 @@ import UIKit
 
 extension UIAccessibilityTraits {
     var descripion: String {
+        guard isStandardTraits else { return "" }
+
         var traits: [String] = []
 
         if contains(.button) {
@@ -82,16 +84,33 @@ extension UIAccessibilityTraits {
             traits.append("startsMediaSession")
         }
 
-        // accessibilityTraits of UITextView and UITextFields are not declared as constant.
-        // - Date: 2022.04.02
-        if rawValue == 262_144 {
-            traits.append("text field")
-        }
-
-        if rawValue == 140_737_488_617_472 {
-            traits.append("text view")
-        }
-
         return traits.joined(separator: ", ")
+    }
+
+    var isStandardTraits: Bool {
+        var standardAccessibilityTraits = UIAccessibilityTraits(arrayLiteral: [
+            .adjustable,
+            .allowsDirectInteraction,
+            .button,
+            .causesPageTurn,
+            .header,
+            .image,
+            .keyboardKey,
+            .link,
+            .none,
+            .notEnabled,
+            .playsSound,
+            .selected,
+            .staticText,
+            .searchField,
+            .summaryElement,
+            .startsMediaSession,
+            .updatesFrequently,
+        ])
+
+        if #available(iOS 10, *) {
+            standardAccessibilityTraits.insert(.tabBar)
+        }
+        return isStrictSubset(of: standardAccessibilityTraits)
     }
 }


### PR DESCRIPTION
Related Ticket: [IOS2-1054](http://banksalad.atlassian.net/browse/IOS2-1054)

UITextView와 UITextField에는 accessibilityTrait이 기본적으로 들어가 있습니다.
그런데 얘네들의 accessibilityTrait은 다른 trait들과 달리, 참조할 수 있는 변수로 만들어져있지 않습니다. 그래서 얘네들의 trait이름은 rawValue로 비교하여 얻어냅니다.