### PR TITLE
[IOS2-1050-5]: Standard UIKit Control의 표현에 대한 테스트코드 추가

### DIFF
--- a/Tests/AXSnapshotTests/AXSnapshotTests.swift
+++ b/Tests/AXSnapshotTests/AXSnapshotTests.swift
@@ -115,6 +115,12 @@ final class AccessibilityDescriptionSnapshotTests: XCTestCase {
 
         let activityIndicator = UIActivityIndicatorView()
         activityIndicator.startAnimating()
+        
+        let textField = UITextField()
+        textField.text = "My TextField Content"
+        
+        let textView = UITextView()
+        textView.text = "My TextView Content"
 
         containerView.addSubview(label)
         containerView.addSubview(button)
@@ -124,6 +130,8 @@ final class AccessibilityDescriptionSnapshotTests: XCTestCase {
         containerView.addSubview(progressView)
         containerView.addSubview(slider)
         containerView.addSubview(activityIndicator)
+        containerView.addSubview(textField)
+        containerView.addSubview(textView)
 
         // When
         let axSnapshot = containerView.axSnapshot()
@@ -150,6 +158,12 @@ final class AccessibilityDescriptionSnapshotTests: XCTestCase {
             adjustable
             ------------------------------------------------------------
             Activity Indicator, Animating
+            ------------------------------------------------------------
+            My TextField Content
+            TextField
+            ------------------------------------------------------------
+            My TextView Content
+            TextView
             ------------------------------------------------------------
             """
         )

--- a/Tests/AXSnapshotTests/AXSnapshotTests.swift
+++ b/Tests/AXSnapshotTests/AXSnapshotTests.swift
@@ -85,6 +85,105 @@ final class AccessibilityDescriptionSnapshotTests: XCTestCase {
             "If Parent View is an accessibilityElement, child cannot be exposed to end user"
         )
     }
+
+    func testStandardUIKitControls() throws {
+        // Given
+        let containerView = UIView()
+        containerView.isAccessibilityElement = false
+
+        let label = UILabel()
+        label.text = "My Label"
+
+        let button = UIButton()
+        button.setTitle("My Button", for: .normal)
+
+        let uiSwitch = UISwitch()
+        uiSwitch.setOn(true, animated: false)
+
+        let segmentedControl = UISegmentedControl(items: ["First", "Second"])
+        segmentedControl.selectedSegmentIndex = 0
+
+        let stepper = UIStepper()
+
+        let progressView = UIProgressView()
+        progressView.progress = 0.7
+
+        let slider = UISlider()
+        slider.minimumValue = 0
+        slider.maximumValue = 100
+        slider.value = 80
+
+        let activityIndicator = UIActivityIndicatorView()
+        activityIndicator.startAnimating()
+
+        containerView.addSubview(label)
+        containerView.addSubview(button)
+        containerView.addSubview(uiSwitch)
+        containerView.addSubview(segmentedControl)
+        containerView.addSubview(stepper)
+        containerView.addSubview(progressView)
+        containerView.addSubview(slider)
+        containerView.addSubview(activityIndicator)
+
+        // When
+        let axSnapshot = containerView.axSnapshot()
+
+        // Then
+        XCTAssert(
+            axSnapshot == """
+            ------------------------------------------------------------
+            My Label
+            ------------------------------------------------------------
+            My Button
+            button
+            ------------------------------------------------------------
+            1
+            button
+            ------------------------------------------------------------
+            SegmentedControl with 2 segments, Selected: First
+            ------------------------------------------------------------
+            Stepper
+            ------------------------------------------------------------
+            70%
+            ------------------------------------------------------------
+            Absolute: 80.0, Percentage: 80%
+            adjustable
+            ------------------------------------------------------------
+            Activity Indicator, Animating
+            ------------------------------------------------------------
+            """
+        )
+    }
+
+    func testHiddenUIKitControls() {
+        // Given
+        let containerView = UIView()
+        containerView.isAccessibilityElement = false
+
+        let label = UILabel()
+        label.text = "My Label"
+        label.isHidden = true
+
+        let button = UIButton()
+        button.setTitle("My Button", for: .normal)
+
+        containerView.addSubview(label)
+        containerView.addSubview(button)
+
+        // When
+        let axSnapshot = containerView.axSnapshot()
+
+        // Then
+        XCTAssert(
+            axSnapshot == """
+            ------------------------------------------------------------
+            My Button
+            button
+            ------------------------------------------------------------
+            """,
+            "Hidden element should not be exposed to axSnapshot"
+        )
+    }
 }
 
 class ListItemView: UIView {


### PR DESCRIPTION
Related Ticket: [IOS2-1055](http://banksalad.atlassian.net/browse/IOS2-1055)

Standard UIKit Control 가 AxSnapshot에서 어떻게 표현되어야 하는지를 표현하고 검증하는 테스트코드를 추가합니다.