### PR TITLE
Replace into organization name properly

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# AXSnapshot [![.github/workflows/test.yml](https://github.com/e-sung/AXSnapshot/actions/workflows/test.yml/badge.svg)](https://github.com/e-sung/AXSnapshot/actions/workflows/test.yml) [![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fe-sung%2FAXSnapshot%2Fbadge%3Ftype%3Dswift-versions)](https://swiftpackageindex.com/e-sung/AXSnapshot) [![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fe-sung%2FAXSnapshot%2Fbadge%3Ftype%3Dplatforms)](https://swiftpackageindex.com/e-sung/AXSnapshot)
+# AXSnapshot [![.github/workflows/test.yml](https://github.com/banksalad/AXSnapshot/actions/workflows/test.yml/badge.svg)](https://github.com/banksalad/AXSnapshot/actions/workflows/test.yml) [![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fbanksalad%2FAXSnapshot%2Fbadge%3Ftype%3Dswift-versions)](https://swiftpackageindex.com/banksalad/AXSnapshot) [![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fbanksalad%2FAXSnapshot%2Fbadge%3Ftype%3Dplatforms)](https://swiftpackageindex.com/banksalad/AXSnapshot)
 
 Text Formatted Snapshot for Accessibility Experience Testing
 
-> Language Switch: [한국어](https://github.com/e-sung/AXSnapshot/blob/main/README_KR.md).
+> Language Switch: [한국어](https://github.com/banksalad/AXSnapshot/blob/main/README_KR.md).
 
 ## Requirements
 


### PR DESCRIPTION
마이그레이션 중 기존 링크로 되어있어 깨진 뱃지 등의 내용을 수정합니다.