### PR TITLE
Mark HidenViews and Views with Hidden Superviews  as "UnExposedToAssistiveTech"

### DIFF
--- a/Sources/AXSnapshot/UIResponder+Extension.swift
+++ b/Sources/AXSnapshot/UIResponder+Extension.swift
@@ -11,7 +11,9 @@ import UIKit
 extension UIResponder {
     var isExposedToAssistiveTech: Bool {
         if shouldForceExposeToAssistiveTech || isAccessibilityElement {
-            if allItemsInResponderChain.contains(where: { $0.isExposedToAssistiveTech }) == true {
+            if hasBlockingElementInResponderChain {
+                return false
+            } else if (self as? UIView)?.isHidden == true {
                 return false
             } else {
                 return true
@@ -19,6 +21,12 @@ extension UIResponder {
         } else {
             return false
         }
+    }
+
+    private var hasBlockingElementInResponderChain: Bool {
+        allItemsInResponderChain.contains(where: { item in
+            item.isExposedToAssistiveTech || (item as? UIView)?.isHidden == true
+        })
     }
 
     /// A boolean value indicates that the elment is exposed to AssistiveTechnology

--- a/Sources/AXSnapshot/UIResponder+Extension.swift
+++ b/Sources/AXSnapshot/UIResponder+Extension.swift
@@ -9,11 +9,10 @@ import Foundation
 import UIKit
 
 extension UIResponder {
+    @objc
     var isExposedToAssistiveTech: Bool {
         if shouldForceExposeToAssistiveTech || isAccessibilityElement {
-            if hasBlockingElementInResponderChain {
-                return false
-            } else if (self as? UIView)?.isHidden == true {
+            if allItemsInResponderChain.contains(where: { $0.isExposedToAssistiveTech }) == true {
                 return false
             } else {
                 return true
@@ -64,5 +63,17 @@ extension UIResponder {
             nextResponder = nextResponder?.next
         }
         return chain
+    }
+}
+
+extension UIView {
+    @objc override var isExposedToAssistiveTech: Bool {
+        if isHidden {
+            return false
+        } else if allItemsInResponderChain.compactMap({ $0 as? UIView }).contains(where: { $0.isHidden }) {
+            return false
+        } else {
+            return super.isExposedToAssistiveTech
+        }
     }
 }

--- a/Tests/AXSnapshotTests/AXSnapshotTests.swift
+++ b/Tests/AXSnapshotTests/AXSnapshotTests.swift
@@ -93,6 +93,7 @@ final class AccessibilityDescriptionSnapshotTests: XCTestCase {
 
         let button = UIButton()
         button.setTitle("MyButton", for: .normal)
+        // Hidden Button shouldn't be exposed to axSnapshot
         button.isHidden = true
 
         let firstListItem = ListItemView()
@@ -102,6 +103,7 @@ final class AccessibilityDescriptionSnapshotTests: XCTestCase {
 
         childStackView.addArrangedSubview(firstListItem)
         childStackView.addArrangedSubview(secondListItem)
+        // all subviews of childStackview shouldn't be exposed to axSnapshot
         childStackView.isHidden = true
 
         parentStackView.addArrangedSubview(label)

--- a/Tests/AXSnapshotTests/AXSnapshotTests.swift
+++ b/Tests/AXSnapshotTests/AXSnapshotTests.swift
@@ -84,6 +84,40 @@ final class AccessibilityDescriptionSnapshotTests: XCTestCase {
         )
     }
 
+    func testHiddenViews() throws {
+        let parentStackView = UIStackView()
+        let childStackView = UIStackView()
+
+        let label = UILabel()
+        label.text = "MyLabel"
+
+        let button = UIButton()
+        button.setTitle("MyButton", for: .normal)
+        button.isHidden = true
+
+        let firstListItem = ListItemView()
+        firstListItem.leftText = "FirstListItem"
+        let secondListItem = ListItemView()
+        secondListItem.leftText = "SecondListItem"
+
+        childStackView.addArrangedSubview(firstListItem)
+        childStackView.addArrangedSubview(secondListItem)
+        childStackView.isHidden = true
+
+        parentStackView.addArrangedSubview(label)
+        parentStackView.addArrangedSubview(button)
+        parentStackView.addArrangedSubview(childStackView)
+
+        XCTAssert(
+            parentStackView.axSnapshot() == """
+            ------------------------------------------------------------
+            MyLabel
+            ------------------------------------------------------------
+            """,
+            "Hidden Views and Views with hidden superViews are not exposed to AssistiveTechnology"
+        )
+    }
+
     func testStandardUIKitControls() throws {
         // Given
         let containerView = UIView()


### PR DESCRIPTION
https://github.com/banksalad/bpl-ios/pull/1449 를 제작하며 발견한 케이스에 대응합니다.

부모뷰가 isHidden이 되면, 자식들도 hidden이 되고, 따라서 AssistiveTechnology에 노출되지 않습니다. 
이 행동을 반영합니다. 

--- 

When parentView becomes `hidden`, its child views become `hidden` as well, which makes them `hidden` to AssistiveTechnology as well. 